### PR TITLE
🔒 Disable Swagger in Production to prevent information disclosure

### DIFF
--- a/KnoxTrafficCenter/Program.cs
+++ b/KnoxTrafficCenter/Program.cs
@@ -41,7 +41,10 @@ app.MapRazorPages();
 
 app.MapControllers();
 
-app.UseSwagger();
-app.UseSwaggerUI();
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
 
 app.Run();

--- a/KnoxTrafficCenter/Program.cs
+++ b/KnoxTrafficCenter/Program.cs
@@ -41,6 +41,7 @@ app.MapRazorPages();
 
 app.MapControllers();
 
+// Ensure Swagger is only available in Development environment to prevent information disclosure
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();


### PR DESCRIPTION
🎯 **What:** Disabled Swagger UI and OpenAPI documentation in non-development environments.
⚠️ **Risk:** Exposing API documentation in production can lead to information disclosure, revealing endpoint structures and schemas to potential attackers.
🛡️ **Solution:** Wrapped the Swagger middleware registration in a conditional check `if (app.Environment.IsDevelopment())`. This ensures that these features are only available during development.

---
*PR created automatically by Jules for task [13097920067871953539](https://jules.google.com/task/13097920067871953539) started by @yoharnu*