### PR TITLE
Refactor TDOTAPIService to use configuration for BaseUrl

### DIFF
--- a/KnoxTrafficCenter/Services/TDOTAPIService.cs
+++ b/KnoxTrafficCenter/Services/TDOTAPIService.cs
@@ -18,9 +18,10 @@ public class TDOTAPIService
     {
         this.logger = logger;
 
+        string baseUrl = configuration.GetValue<string>("TDOTApi:BaseUrl") ?? throw new ArgumentNullException("TDOTApi:BaseUrl", "TDOT API Base URL must be configured.");
         HttpClient = new HttpClient
         {
-            BaseAddress = new Uri("https://smartway.tn.gov/config/")
+            BaseAddress = new Uri(baseUrl)
         };
         HttpClient.DefaultRequestHeaders.Accept.Clear();
         HttpClient.DefaultRequestHeaders.Accept.Add(

--- a/KnoxTrafficCenter/appsettings.json
+++ b/KnoxTrafficCenter/appsettings.json
@@ -7,6 +7,7 @@
   },
   "AllowedHosts": "*",
   "TDOTApi": {
-    "ConfigRefreshIntervalHours": 24
+    "ConfigRefreshIntervalHours": 24,
+    "BaseUrl": "https://smartway.tn.gov/config/"
   }
 }


### PR DESCRIPTION
## 🎯 What
Refactored `TDOTAPIService` to remove the hardcoded URL `https://smartway.tn.gov/config/` and instead load it from `appsettings.json`.

## 💡 Why
Hardcoded URLs make it difficult to change environments or update the API endpoint without recompiling the code. Moving this to configuration follows best practices and improves the maintainability of the codebase.

## ✅ Verification
- Built the project successfully.
- Ran the application locally and verified that it successfully connects to the TDOT API and retrieves data (incidents).
- Checked logs to confirm "Successfully refreshed TDOT API configuration".

## ✨ Result
The `TDOTAPIService` now reads its base URL from the configuration, making it more flexible and robust.

---
*PR created automatically by Jules for task [15043011819830091389](https://jules.google.com/task/15043011819830091389) started by @yoharnu*