### PR TITLE
🧹 cleanup redundant using directives in AlertsController.cs

### DIFF
--- a/KnoxTrafficCenter/Controllers/AlertsController.cs
+++ b/KnoxTrafficCenter/Controllers/AlertsController.cs
@@ -1,9 +1,3 @@
-using Microsoft.AspNetCore.Mvc;
-using KnoxTrafficCenter.Services;
-using System.Threading.Tasks;
-using KnoxTrafficCenter.Models.TDOT;
-using System.Collections.Generic;
-
 namespace KnoxTrafficCenter.Controllers
 {
     [ApiController]


### PR DESCRIPTION
Removed redundant using directives from AlertsController.cs. These namespaces are either covered by implicit usings or are not explicitly used in the file. This keeps the code clean and reduces visual clutter.

---
*PR created automatically by Jules for task [10743808295933358713](https://jules.google.com/task/10743808295933358713) started by @yoharnu*