### PR TITLE
🔒 Remove sensitive data exposure in TDOTAPIService logging

### DIFF
--- a/KnoxTrafficCenter/Services/TDOTAPIService.cs
+++ b/KnoxTrafficCenter/Services/TDOTAPIService.cs
@@ -95,11 +95,9 @@ public class TDOTAPIService
             httpClient.DefaultRequestHeaders.Add("apikey", api.APIKey);
 
             logger.LogDebug($"Using API Base URL: {api.APIBaseURL}");
-            logger.LogDebug($"Using headers: {httpClient.DefaultRequestHeaders.ToString()}");
             logger.LogDebug($"Requesting cameras from: {api.Cameras}");
 
             var response = await httpClient.GetAsync(api.Cameras);
-            logger.LogDebug(response.ToString());
             if (response.IsSuccessStatusCode)
             {
                 var stream = await response.Content.ReadAsStreamAsync();
@@ -155,11 +153,9 @@ public class TDOTAPIService
             httpClient.DefaultRequestHeaders.Add("apikey", api.APIKey);
 
             logger.LogDebug($"Using API Base URL: {api.APIBaseURL}");
-            logger.LogDebug($"Using headers: {httpClient.DefaultRequestHeaders.ToString()}");
             logger.LogDebug($"Requesting incidents from: {api.Incidents}");
 
             var response = await httpClient.GetAsync(api.Incidents);
-            logger.LogDebug(response.ToString());
             if (response.IsSuccessStatusCode)
             {
                 var stream = await response.Content.ReadAsStreamAsync();
@@ -194,11 +190,9 @@ public class TDOTAPIService
             httpClient.DefaultRequestHeaders.Add("apikey", api.APIKey);
 
             logger.LogDebug($"Using API Base URL: {api.APIBaseURL}");
-            logger.LogDebug($"Using headers: {httpClient.DefaultRequestHeaders.ToString()}");
             logger.LogDebug($"Requesting construction events from: {api.Construction}");
 
             var response = await httpClient.GetAsync(api.Construction);
-            logger.LogDebug(response.ToString());
             if (response.IsSuccessStatusCode)
             {
                 var stream = await response.Content.ReadAsStreamAsync();
@@ -231,11 +225,9 @@ public class TDOTAPIService
             httpClient.DefaultRequestHeaders.Add("apikey", api.APIKey);
 
             logger.LogDebug($"Using API Base URL: {api.APIBaseURL}");
-            logger.LogDebug($"Using headers: {httpClient.DefaultRequestHeaders}");
             logger.LogDebug($"Requesting weather events from: {api.Weather}");
 
             var response = await httpClient.GetAsync(api.Weather);
-            logger.LogDebug(response.ToString());
             if (response.IsSuccessStatusCode)
             {
                 var stream = await response.Content.ReadAsStreamAsync();


### PR DESCRIPTION
This pull request fixes a security vulnerability where sensitive information (API key) was being exposed in application logs.

🎯 **What:** Removed sensitive logging in `KnoxTrafficCenter/Services/TDOTAPIService.cs`.
⚠️ **Risk:** The `apikey` used for authenticating with the TDOT API was being logged in plaintext via `DefaultRequestHeaders`. If logs were compromised, an attacker could gain unauthorized access to the API.
🛡️ **Solution:** Removed the `logger.LogDebug` statements that logged the entire request headers and the response object, as both could contain sensitive data.

Specifically, the following changes were made in `TDOTAPIService.cs`:
- Removed logging of `httpClient.DefaultRequestHeaders` in `GetCamerasAsync`, `GetIncidentsAsync`, `GetConstructionAsync`, and `GetWeatherAsync`.
- Removed logging of `response.ToString()` in the same methods.

---
*PR created automatically by Jules for task [5189272126321739769](https://jules.google.com/task/5189272126321739769) started by @yoharnu*