### PR TITLE
Palette: Add play overlay to camera cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - [Interactive Camera Cards]
+**Learning:** Using a <button> instead of <a> for modal triggers is semantically correct but requires careful styling (resetting borders, padding) to match the visual of a card image.
+**Action:** When converting image links to buttons, use utility classes like 'p-0 border-0 w-100' and ensure border-radius is handled correctly.

--- a/KnoxTrafficCenter/Pages/Index.cshtml
+++ b/KnoxTrafficCenter/Pages/Index.cshtml
@@ -33,9 +33,17 @@
                             <h6 class="text-muted card-subtitle">MM @camera.MM</h6>
                         }
                     </div>
-                    <a href="#" data-bs-toggle="modal" data-bs-target="#videoModal" data-bs-title="@camera.Title" data-bs-video-url="@(camera.Video.URL)">
-                        <img src="@camera.Image.URL" class="card-img-bottom img-fluid" alt="camera image of @camera.Title" loading="lazy" />
-                    </a>
+                    <button type="button" class="btn p-0 border-0 w-100 camera-card-btn position-relative rounded-bottom"
+                            data-bs-toggle="modal"
+                            data-bs-target="#videoModal"
+                            data-bs-title="@camera.Title"
+                            data-bs-video-url="@(camera.Video.URL)"
+                            aria-label="View live camera feed for @camera.Title">
+                        <img src="@camera.Image.URL" class="card-img-bottom img-fluid w-100" alt="" loading="lazy" />
+                        <span class="play-overlay">
+                            <i class="bi bi-play-fill text-white fs-1"></i>
+                        </span>
+                    </button>
                 </div>
             </div>
         }

--- a/KnoxTrafficCenter/wwwroot/css/site.css
+++ b/KnoxTrafficCenter/wwwroot/css/site.css
@@ -105,3 +105,40 @@ body {
         max-width: 1600px;
     }
 }
+
+/* Camera Card Play Overlay - Added by Palette */
+.camera-card-btn {
+    position: relative;
+    overflow: hidden;
+    cursor: pointer;
+}
+
+.camera-card-btn .play-overlay {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 60px;
+    height: 60px;
+    background-color: rgba(0, 0, 0, 0.6);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    pointer-events: none;
+}
+
+.camera-card-btn:hover .play-overlay,
+.camera-card-btn:focus .play-overlay {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1.1);
+}
+
+/* Ensure focus ring is visible and accessible */
+.camera-card-btn:focus {
+    outline: 3px solid #0d6efd;
+    outline-offset: -3px;
+    z-index: 1;
+}


### PR DESCRIPTION
💡 **What:**
- Replaced the camera preview image links (wrapped in `<a>`) with `<button type="button">` elements.
- Added a play icon overlay that appears on hover/focus.
- Added clear `aria-label` to the buttons describing the action ("View live camera feed for [Title]").

🎯 **Why:**
- Improves accessibility by using the correct semantic element for a modal trigger.
- Provides better affordance that the camera preview is clickable and will play a video.
- Ensures keyboard users have a clear focus indicator and descriptive label.

♿ **Accessibility:**
- Replaced `href="#"` with `<button>`.
- Added `aria-label` for screen readers.
- Ensured focus ring visibility via custom CSS.
- Used `alt=""` for the image inside the button as the button label provides context.

📸 **Visual Changes:**
- Added a play icon overlay centered on the image with a subtle hover effect.

---
*PR created automatically by Jules for task [17794743774011526797](https://jules.google.com/task/17794743774011526797) started by @yoharnu*