### PR TITLE
Add missing using statements to AlertsController.cs

### DIFF
--- a/KnoxTrafficCenter/Controllers/AlertsController.cs
+++ b/KnoxTrafficCenter/Controllers/AlertsController.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Mvc;
+using KnoxTrafficCenter.Services;
 namespace KnoxTrafficCenter.Controllers
 {
     [ApiController]


### PR DESCRIPTION
Added `using Microsoft.AspNetCore.Mvc;` and `using KnoxTrafficCenter.Services;` to `KnoxTrafficCenter/Controllers/AlertsController.cs` to resolve compilation errors. Verified with `dotnet build`.

---
*PR created automatically by Jules for task [2447471913248881969](https://jules.google.com/task/2447471913248881969) started by @yoharnu*