### PR TITLE
Fix GitHub workflow and test project configuration

### DIFF
--- a/.github/workflows/v2_knoxtntrafficcenter2.yml
+++ b/.github/workflows/v2_knoxtntrafficcenter2.yml
@@ -23,17 +23,23 @@ jobs:
         with:
           dotnet-version: '8.0'
 
+      - name: dotnet restore
+        run: dotnet restore
+
       - name: Build with dotnet
-        run: dotnet build --configuration Release
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test with dotnet
+        run: dotnet test --configuration Release --no-build
 
       - name: dotnet publish
-        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish KnoxTrafficCenter/KnoxTrafficCenter.csproj -c Release -o myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4
         with:
           name: .net-app
-          path: ${{env.DOTNET_ROOT}}/myapp
+          path: myapp
 
   deploy:
     runs-on: ubuntu-latest
@@ -50,6 +56,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: .net-app
+          path: .
       
       - name: Login to Azure
         uses: azure/login@v2
@@ -65,4 +72,3 @@ jobs:
           app-name: 'KnoxTNTrafficCenter2'
           slot-name: 'Production'
           package: .
-          

--- a/KnoxTrafficCenter.Tests/KnoxTrafficCenter.Tests.csproj
+++ b/KnoxTrafficCenter.Tests/KnoxTrafficCenter.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This PR fixes issues with the GitHub workflow that were causing build and deployment problems. Specifically, it corrects the target framework for the test project (which was set to a non-existent `net10.0`), ensures that `dotnet publish` only includes the main application (excluding test assemblies), and fixes the artifact output path usage in the workflow. It also adds a test step to the workflow to ensure code quality before deployment.

---
*PR created automatically by Jules for task [17767428918440653232](https://jules.google.com/task/17767428918440653232) started by @yoharnu*