### PR TITLE
🧹 Refactor: Extract hardcoded excluded roads to static field

### DIFF
--- a/KnoxTrafficCenter/Services/TDOTAPIService.cs
+++ b/KnoxTrafficCenter/Services/TDOTAPIService.cs
@@ -8,6 +8,11 @@ namespace KnoxTrafficCenter.Services;
 
 public class TDOTAPIService
 {
+    private static readonly HashSet<string> _excludedRoads = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "I-40", "I-640", "I-75", "I-275", "I-140", "SR-162", "SR-115", "US-129"
+    };
+
     protected HttpClient _httpClient;
     private ILogger<TDOTAPIService> logger;
     private TDOTAPI? api;
@@ -132,10 +137,9 @@ public class TDOTAPIService
                 if (cameraGroups.Contains("SR-115")) sr115Group.AddRange(cameraGroups["SR-115"]);
 
                 var otherGroup = new CameraGroup("Other");
-                var excludedRoads = new HashSet<string> { "I-40", "I-640", "I-75", "I-275", "I-140", "SR-162", "SR-115", "US-129" };
                 foreach (var group in cameraGroups)
                 {
-                    if (!excludedRoads.Contains(group.Key))
+                    if (!_excludedRoads.Contains(group.Key))
                     {
                         otherGroup.AddRange(group);
                     }


### PR DESCRIPTION
🎯 **What:** Extracted the hardcoded `excludedRoads` list of strings into a `private static readonly HashSet<string> _excludedRoads` at the class level of `TDOTAPIService.cs`. Also added `StringComparer.OrdinalIgnoreCase` for more robust string comparison.
💡 **Why:** It removes magic strings from the body of `GetCamerasAsync`, making the code easier to read and maintain. The object is also only allocated once instead of every time the method is called.
✅ **Verification:** Verified by compiling the project successfully and running the test suite, which all passed without regressions.
✨ **Result:** A slightly cleaner and more performant code block within `TDOTAPIService`.

---
*PR created automatically by Jules for task [10132210070408334994](https://jules.google.com/task/10132210070408334994) started by @yoharnu*