### PR TITLE
🧪 Add comprehensive unit tests for GetConstructionAsync

### DIFF
--- a/KnoxTrafficCenter.Tests/Services/TDOTAPIServiceTests.cs
+++ b/KnoxTrafficCenter.Tests/Services/TDOTAPIServiceTests.cs
@@ -179,6 +179,102 @@ public class TDOTAPIServiceTests
     }
 
     [Fact]
+    public async Task GetConstructionAsync_ReturnsEmptyList_WhenApiConfigIsNull()
+    {
+        // Arrange
+        // Simulate a failure to get the config
+        _httpHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().EndsWith("config.prod.json")),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.InternalServerError
+            });
+
+        // Act
+        var result = await _service.GetConstructionAsync();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetConstructionAsync_ReturnsEmptyList_WhenApiFails()
+    {
+        // Arrange
+        var tdotApi = new TDOTAPI
+        {
+            APIBaseURL = "https://api.tdot.com/",
+            APIKey = "key123",
+            Construction = "construction"
+        };
+        SetupConfigResponse(tdotApi);
+
+        _httpHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString() == "https://api.tdot.com/construction"),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.InternalServerError
+            });
+
+        // Act
+        var result = await _service.GetConstructionAsync();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetConstructionAsync_ReturnsKnoxConstruction()
+    {
+        // Arrange
+        var tdotApi = new TDOTAPI
+        {
+            APIBaseURL = "https://api.tdot.com/",
+            APIKey = "key123",
+            Construction = "construction"
+        };
+        SetupConfigResponse(tdotApi);
+
+        var constructionEvents = new List<Event>
+        {
+            new() { Id = 1, Locations = [new Location { CountyName = "Knox" }] },
+            new() { Id = 2, Locations = [new Location { CountyName = "Davidson" }] }
+        };
+
+        var constructionJson = JsonSerializer.Serialize(constructionEvents);
+
+        _httpHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString() == "https://api.tdot.com/construction"),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(constructionJson)
+            });
+
+        // Act
+        var result = await _service.GetConstructionAsync();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(1);
+        result.First().Id.Should().Be(1);
+    }
+
+    [Fact]
     public async Task GetWeatherAsync_ReturnsKnoxWeather()
     {
         // Arrange


### PR DESCRIPTION
🎯 **What:** Added comprehensive unit tests for the previously untested `GetConstructionAsync` method in `TDOTAPIService.cs` to ensure better code reliability and prevent regressions.

📊 **Coverage:** The new tests cover the following scenarios:
1.  **Happy Path:** `GetConstructionAsync_ReturnsKnoxConstruction` verifies that when the API returns a successful response, only the construction events relevant to "Knox" county are returned, correctly filtering out events from other counties (e.g., Davidson).
2.  **API Failure:** `GetConstructionAsync_ReturnsEmptyList_WhenApiFails` verifies that when the API returns an error HTTP status code (e.g., 500 Internal Server Error), the method gracefully returns an empty list instead of throwing an exception.
3.  **Configuration Failure:** `GetConstructionAsync_ReturnsEmptyList_WhenApiConfigIsNull` verifies that if the application fails to fetch the necessary TDOT API configuration initially, the method safely returns an empty list.

✨ **Result:** Test coverage for `TDOTAPIService` has significantly improved, ensuring the robustness of the construction events retrieval feature and matching the testing standard of similar methods like `GetIncidentsAsync` and `GetWeatherAsync`. The overall number of passing tests has increased from 5 to 8.

---
*PR created automatically by Jules for task [5410368145989269696](https://jules.google.com/task/5410368145989269696) started by @yoharnu*