### PR TITLE
⚡ Optimize HashSet instantiation in TDOTAPIService

### DIFF
--- a/KnoxTrafficCenter/Services/TDOTAPIService.cs
+++ b/KnoxTrafficCenter/Services/TDOTAPIService.cs
@@ -13,6 +13,7 @@ public class TDOTAPIService
     private TDOTAPI? api;
     private DateTime lastConfigRefresh = DateTime.MinValue;
     private readonly TimeSpan configRefreshInterval = TimeSpan.FromHours(24);
+    private static readonly HashSet<string> ExcludedRoads = ["I-40", "I-640", "I-75", "I-275", "I-140", "SR-162", "SR-115", "US-129"];
 
     public TDOTAPIService(ILogger<TDOTAPIService> logger, IConfiguration configuration)
     {
@@ -156,10 +157,9 @@ public class TDOTAPIService
         if (cameraGroups.Contains("SR-115")) sr115Group.AddRange(cameraGroups["SR-115"]);
 
         var otherGroup = new CameraGroup("Other");
-        var excludedRoads = new HashSet<string> { "I-40", "I-640", "I-75", "I-275", "I-140", "SR-162", "SR-115", "US-129" };
         foreach (var group in cameraGroups)
         {
-            if (!excludedRoads.Contains(group.Key))
+            if (!ExcludedRoads.Contains(group.Key))
             {
                 otherGroup.AddRange(group);
             }


### PR DESCRIPTION
### 💡 What:
Moved the `excludedRoads` HashSet in `TDOTAPIService.cs` from a local variable within `GetCamerasAsync` to a `private static readonly` field.

### 🎯 Why:
The `GetCamerasAsync` method was previously instantiating a new `HashSet<string>` on every call. Since the list of excluded roads is static, reusing a single instance reduces memory pressure and CPU cycles spent on allocation and initialization.

### 📊 Measured Improvement:
While environment restrictions (specifically NuGet restore timeouts) prevented establishing a formal benchmark baseline within the sandbox, this change is a well-recognized O(1) space optimization for static configuration data in .NET. It ensures that read-only lookups against the exclusion list are as efficient as possible without redundant overhead.

---
*PR created automatically by Jules for task [6717087355385037986](https://jules.google.com/task/6717087355385037986) started by @yoharnu*